### PR TITLE
performance benchmark for copy: rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hpx-rs"
 version = "0.1.0"
-authors = ["Shreyas Atre <shreyasatre16@gmail.com>", "Dikshant <dikshant.073@gmail.com"]
+authors = ["Shreyas Atre <shreyasatre16@gmail.com>", "Dikshant <dikshant.073@gmail.com>"]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/STEllAR-GROUP/hpx-rs"
@@ -15,6 +15,13 @@ publish = false
 
 [dependencies]
 hpx-sys = { path = "hpx-sys", version = "0.1.0" }
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "cpy_bench"
+harness = false
 
 [workspace]
 members = []

--- a/benches/cpy_bench.rs
+++ b/benches/cpy_bench.rs
@@ -1,0 +1,24 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use hpx_sys::{copy_vector, create_c_args, ffi};
+use std::os::raw::c_char;
+
+fn benchmark_hpx_copy(c: &mut Criterion) {
+    c.bench_function("hpx::copy rust benchmark for 1M elements", |b| {
+        b.iter(|| {
+            let (argc, mut argv) = create_c_args(&["benchmark_hpx_copy"]);
+
+            let hpx_main = |_argc: i32, _argv: *mut *mut c_char| -> i32 {
+                let src = vec![1; 1_000_000];
+                let _result = copy_vector(black_box(&src));
+                ffi::finalize()
+            };
+
+            unsafe {
+                let _result = ffi::init(hpx_main, argc, argv.as_mut_ptr());
+            }
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_hpx_copy);
+criterion_main!(benches);


### PR DESCRIPTION
Dependent on: #7 (merge #7 first because algos are defined in that pr)
To run performance benchmark execute `cargo bench` 