### PR TITLE
Add example for parallel sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 readme = "README.md"
 repository = "https://github.com/STEllAR-GROUP/hpx-rs"
 description = """
-Bindings to hpx for interoperating with stellar-group hpx library for 
+Bindings to hpx for interoperating with stellar-group hpx library for
 concurrency and parallelism.
 """
 categories = ["api-bindings"]
@@ -17,4 +17,4 @@ publish = false
 hpx-sys = { path = "hpx-sys", version = "0.1.0" }
 
 [workspace]
-members = []
+members = [ "hpx-examples"]

--- a/hpx-examples/Cargo.toml
+++ b/hpx-examples/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hpx-examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hpx-sys = { path = "../hpx-sys", version = "0.1.0" }

--- a/hpx-examples/Cargo.toml
+++ b/hpx-examples/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 hpx-sys = { path = "../hpx-sys", version = "0.1.0" }
+rand = "0.8.5"

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -1,6 +1,6 @@
 use core::array::from_fn;
-use std::{env, process};
 use rand;
+use std::{env, process};
 
 fn hpx_main(_: Vec<String>) -> i32 {
     let numbers: &[i32; 16384] = &from_fn(|_| rand::random::<i32>());

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -1,10 +1,9 @@
-#![feature(vec_into_raw_parts)]
-#![feature(random)]
 use core::array::from_fn;
-use std::{env, process, random};
+use std::{env, process};
+use rand;
 
 fn hpx_main(_: Vec<String>) -> i32 {
-    let numbers: &[i32; 16384] = &from_fn(|_| random::random::<i32>());
+    let numbers: &[i32; 16384] = &from_fn(|_| rand::random::<i32>());
     let list: &mut Vec<i32> = &mut Vec::<i32>::from(numbers);
     println!("{:#?}", list);
     // Sort the array in parallel.

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(vec_into_raw_parts)]
 #![feature(random)]
 use core::array::from_fn;
-use std::{env, ffi::c_char, process, random};
+use std::{env, process, random};
 
 fn hpx_main(_: Vec<String>) -> i32 {
     let numbers: &[i32; 16384] = &from_fn(|_| random::random::<i32>());

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -1,12 +1,11 @@
 #![feature(vec_into_raw_parts)]
 #![feature(random)]
 use core::array::from_fn;
-use std::{process, random, ffi::c_char, env};
+use std::{env, ffi::c_char, process, random};
 
 use hpx_sys as hpx;
 
 fn hpx_main(argc: i32, argv: *mut *mut c_char) -> i32 {
-
     let numbers: &[i32; 16384] = &from_fn(|_| random::random::<i32>());
     let list: &mut Vec<i32> = &mut Vec::<i32>::from(numbers);
     println!("{:#?}", list);
@@ -18,15 +17,14 @@ fn hpx_main(argc: i32, argv: *mut *mut c_char) -> i32 {
 }
 fn main() {
     let args = env::args();
-    let (argc, argv) = hpx::create_c_args(&args
-        .collect::<Vec<String>>()
-        .iter()
-        .map(|s| s.as_str())
-        .collect::<Vec<&str>>()
+    let (argc, argv) = hpx::create_c_args(
+        &args
+            .collect::<Vec<String>>()
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>(),
     );
     unsafe {
-    process::exit(hpx::init(hpx_main, argc, argv
-            .into_raw_parts()
-            .0));
+        process::exit(hpx::init(hpx_main, argc, argv.into_raw_parts().0));
     }
 }

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -3,28 +3,17 @@
 use core::array::from_fn;
 use std::{env, ffi::c_char, process, random};
 
-use hpx_sys as hpx;
-
-fn hpx_main(argc: i32, argv: *mut *mut c_char) -> i32 {
+fn hpx_main(_: Vec<String>) -> i32 {
     let numbers: &[i32; 16384] = &from_fn(|_| random::random::<i32>());
     let list: &mut Vec<i32> = &mut Vec::<i32>::from(numbers);
     println!("{:#?}", list);
     // Sort the array in parallel.
-    hpx::hpx_sort_comp(list, |a, b| a < b);
+    hpx_sys::ffi::hpx_sort_comp(list, |a, b| a < b);
     println!("{:#?}", list);
-    hpx::finalize();
+    hpx_sys::ffi::finalize();
     return 0;
 }
 fn main() {
-    let args = env::args();
-    let (argc, argv) = hpx::create_c_args(
-        &args
-            .collect::<Vec<String>>()
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<&str>>(),
-    );
-    unsafe {
-        process::exit(hpx::init(hpx_main, argc, argv.into_raw_parts().0));
-    }
+    let args = env::args().collect::<Vec<String>>();
+    process::exit(hpx_sys::init(hpx_main, args));
 }

--- a/hpx-examples/src/main.rs
+++ b/hpx-examples/src/main.rs
@@ -1,0 +1,32 @@
+#![feature(vec_into_raw_parts)]
+#![feature(random)]
+use core::array::from_fn;
+use std::{process, random, ffi::c_char, env};
+
+use hpx_sys as hpx;
+
+fn hpx_main(argc: i32, argv: *mut *mut c_char) -> i32 {
+
+    let numbers: &[i32; 16384] = &from_fn(|_| random::random::<i32>());
+    let list: &mut Vec<i32> = &mut Vec::<i32>::from(numbers);
+    println!("{:#?}", list);
+    // Sort the array in parallel.
+    hpx::hpx_sort_comp(list, |a, b| a < b);
+    println!("{:#?}", list);
+    hpx::finalize();
+    return 0;
+}
+fn main() {
+    let args = env::args();
+    let (argc, argv) = hpx::create_c_args(&args
+        .collect::<Vec<String>>()
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<&str>>()
+    );
+    unsafe {
+    process::exit(hpx::init(hpx_main, argc, argv
+            .into_raw_parts()
+            .0));
+    }
+}

--- a/hpx-sys/src/lib.rs
+++ b/hpx-sys/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ffi {
         fn hpx_partial_sort_comp(src: &mut Vec<i32>, last: usize, comp: fn(i32, i32) -> bool);
     }
 }
+pub use self::ffi::*;
 
 // ================================================================================================
 // Wrapper for the above Bindings.

--- a/hpx-sys/src/lib.rs
+++ b/hpx-sys/src/lib.rs
@@ -44,7 +44,7 @@ use std::env::Args;
 use std::ffi::{CString, CStr};
 use std::os::raw::c_char;
 
-static FUNC_HOLDER: Option<fn (Vec<String>) -> i32> = None;
+static mut FUNC_HOLDER: Option<fn (Vec<String>) -> i32> = None;
 
 // Convert arguments from *mut *mut c_char to Vec<String>
 // and call the saved Rust version of the function.
@@ -66,7 +66,7 @@ fn c_init(argc: i32, argv: *mut *mut c_char) -> i32 {
 
 pub fn init(func: fn(Vec<String>) -> i32, func_args: Vec<String>) -> i32
 {
-    FUNC_HOLDER = unsafe { Some(func) };
+    unsafe { FUNC_HOLDER = Some(func) };
     let str_args: Vec<&str> = func_args
         .iter()
         .map(|s| s.as_str())

--- a/hpx-sys/src/lib.rs
+++ b/hpx-sys/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://github.com/STEllAR-GROUP/hpx-rs")]
 #![allow(bad_style, non_camel_case_types, unused_extern_crates)]
 #![allow(dead_code, unused_imports)]
-#![feature(vec_into_raw_parts)]
 
 #[cxx::bridge]
 pub mod ffi {
@@ -71,8 +70,8 @@ pub fn init(func: fn(Vec<String>) -> i32, func_args: Vec<String>) -> i32
         .iter()
         .map(|s| s.as_str())
         .collect::<Vec<&str>>();
-    let (argc, rust_argv) = create_c_args(&str_args);
-    let argv = rust_argv.into_raw_parts().0;
+    let (argc, mut rust_argv) = create_c_args(&str_args);
+    let argv = rust_argv.as_mut_ptr();
 
     unsafe {
         return self::ffi::init(c_init, argc, argv);

--- a/hpx-sys/src/lib.rs
+++ b/hpx-sys/src/lib.rs
@@ -40,10 +40,10 @@ pub mod ffi {
 // reffer to tests to understand how to use them. [NOTE: Not all bindings have wrapper.]
 // ================================================================================================
 use std::env::Args;
-use std::ffi::{CString, CStr};
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
-static mut FUNC_HOLDER: Option<fn (Vec<String>) -> i32> = None;
+static mut FUNC_HOLDER: Option<fn(Vec<String>) -> i32> = None;
 
 // Convert arguments from *mut *mut c_char to Vec<String>
 // and call the saved Rust version of the function.
@@ -63,13 +63,9 @@ fn c_init(argc: i32, argv: *mut *mut c_char) -> i32 {
     unsafe { FUNC_HOLDER.unwrap()(vec_args) }
 }
 
-pub fn init(func: fn(Vec<String>) -> i32, func_args: Vec<String>) -> i32
-{
+pub fn init(func: fn(Vec<String>) -> i32, func_args: Vec<String>) -> i32 {
     unsafe { FUNC_HOLDER = Some(func) };
-    let str_args: Vec<&str> = func_args
-        .iter()
-        .map(|s| s.as_str())
-        .collect::<Vec<&str>>();
+    let str_args: Vec<&str> = func_args.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
     let (argc, mut rust_argv) = create_c_args(&str_args);
     let argv = rust_argv.as_mut_ptr();
 


### PR DESCRIPTION
It is now clearer how to use this library. The example(s) are built by default.
